### PR TITLE
Change next path to use underscore

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -46,15 +46,7 @@ cd "${build}/"
 
 for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path './.heroku/*' | cut -c 3-); do
     sum=$(sha1sum "./${map}" | cut -c -40)
-    name="~/${map}"
-    
-    # Check if we have a '.next' directory for Next.js
-    # Need to modify $name to represent with BUILD_ID from Next.js
-    if [ -d "./.next/" ]; then
-        next_id=$(cat "./.next/BUILD_ID")
-        next_path="~/_next/$next_id/"
-        name="${name/"~/.next/dist/bundles/"/$next_path}"
-    fi
+    name="~/${map/.next/_next}"
    
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))
 


### PR DESCRIPTION
For our needs, we just need the path renamed from `.next` to `_next` and all other pathing should be the same.