### PR TITLE
Update api endpoint to point to org

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ if [[ ! -f "${JQ}" ]]; then
     chmod +x "${JQ}"
 fi
 
-API="https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}"
+API="https://sentry.io/api/0/organizations/${SENTRY_ORG}"
 
 # Create a release
 echo "-----> Creating Sentry release ${SOURCE_VERSION} for organization '${SENTRY_ORG}' in project '${SENTRY_PROJECT}'"
@@ -30,16 +30,8 @@ curl -sSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
   -H 'Content-Type: application/json' \
-  -d "{\"version\": \"${SOURCE_VERSION}\"}" \
+  -d "{\"version\": \"${SOURCE_VERSION}\", \"projects\": [\"${SENTRY_PROJECT}\"]}" \
   >/dev/null
-
-# Retrieve files
-files=$(mktemp)
-echo "       Retrieving existing files to $files"
-curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
-     -X GET \
-     -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-     > "$files"
 
 # Upload the sourcemaps
 cd "${build}/"
@@ -49,40 +41,19 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     name="~/${map}"
     
     # Check if we have a '.next' directory for Next.js
-    # Need to modify $name to represent with BUILD_ID from Next.js
     if [ -d "./.next/" ]; then
         next_id=$(cat "./.next/BUILD_ID")
         next_path="~/_next/$next_id/"
         name="${name/"~/.next/dist/bundles/"/$next_path}"
     fi
-   
-    res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))
 
-    if [[ "${res[0]}" == "" ]]; then
-        echo "       Uploading ${map} to Sentry"
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
-             -X POST \
-             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-             -F file=@"${map}" \
-             -F name="${name}" \
-             >/dev/null
-
-    elif [[ "${res[1]}" != "${sum}" ]]; then
-        echo "       Updating ${map} on Sentry"
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/${res[0]}/" \
-             -X DELETE \
-             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-             >/dev/null
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
-             -X POST \
-             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-             -F file=@"${map}" \
-             -F name="${name}" \
-             >/dev/null
-
-    else
-        echo "       ${map} is up-to-date"
-    fi
+    echo "       Uploading ${map} to Sentry"
+    curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+            -X POST \
+            -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+            -F file=@"${map}" \
+            -F name="${name}" \
+            >/dev/null
 
     # remove sourcemap from slug
     echo "       Removing ${map} from slug"

--- a/bin/compile
+++ b/bin/compile
@@ -41,11 +41,11 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
 
     echo "       Uploading ${map} to Sentry"
     curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
-            -X POST \
-            -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-            -F file=@"${map}" \
-            -F name="${name}" \
-            >/dev/null
+        -X POST \
+        -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+        -F file=@"${map}" \
+        -F name="${name}" \
+        >/dev/null
 
     # remove sourcemap from slug
     echo "       Removing ${map} from slug"


### PR DESCRIPTION
This changes the api to use the updated `/organizations/` as stated here: https://docs.sentry.io/workflow/releases/?platform=javascript#using-the-api

I also removed some unnecessary parts dealing with updating releases, since we want a new release with every publish.